### PR TITLE
feat: Implement getQueuePosition query for waiting list management

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -15,7 +15,9 @@ import type {
 } from "convex/server";
 import type * as constant from "../constant.js";
 import type * as events from "../events.js";
+import type * as tickets from "../tickets.js";
 import type * as users from "../users.js";
+import type * as waitingList from "../waitingList.js";
 
 /**
  * A utility for referencing Convex functions in your app's API.
@@ -28,7 +30,9 @@ import type * as users from "../users.js";
 declare const fullApi: ApiFromModules<{
   constant: typeof constant;
   events: typeof events;
+  tickets: typeof tickets;
   users: typeof users;
+  waitingList: typeof waitingList;
 }>;
 export declare const api: FilterApi<
   typeof fullApi,

--- a/convex/tickets.ts
+++ b/convex/tickets.ts
@@ -17,3 +17,5 @@ export const getUserTicketForEvent = query({
     return ticket;
   },
 });
+
+

--- a/convex/waitingList.ts
+++ b/convex/waitingList.ts
@@ -1,0 +1,52 @@
+import { query } from "./_generated/server";
+import { v } from "convex/values";
+import { WAITING_LIST_STATUS } from "./constant";
+
+/**
+ * Query to get a user's current position in the waiting list for an event.
+ * Returns null if user is not in queue, otherwise returns their entry with position.
+ */
+export const getQueuePosition = query({
+  args: {
+    eventId: v.id("events"),
+    userId: v.string(),
+  },
+  handler: async (ctx, { eventId, userId }) => {
+    // Get entry for this specific user and event combination
+    const entry = await ctx.db
+      .query("waitingList")
+      .withIndex("by_user_event", (q) =>
+        q.eq("userId", userId).eq("eventId", eventId),
+      )
+      .filter((q) => q.neq(q.field("status"), WAITING_LIST_STATUS.EXPIRED)) //filter out where its not equal to expired ticket{returns open tickets }
+      .first();
+
+    if (!entry) return null;
+
+    // Get total number of people ahead in line
+    const peopleAhead = await ctx.db
+      .query("waitingList")
+      // Use the index to filter entries by event ID
+      .withIndex("by_event_status", (q) => q.eq("eventId", eventId))
+      .filter((q) =>
+        q.and(
+          // Filter entries created before the current user's entry
+          q.lt(q.field("_creationTime"), entry._creationTime),
+          // Include only entries with status 'WAITING' or 'OFFERED'
+          q.or(
+            q.eq(q.field("status"), WAITING_LIST_STATUS.WAITING),
+            q.eq(q.field("status"), WAITING_LIST_STATUS.OFFERED),
+          ),
+        ),
+      )
+      // Collect all matching entries and count them
+      .collect()
+      .then((entries) => entries.length);
+
+    // Return the user's entry with their position in the queue
+    return {
+      ...entry,
+      position: peopleAhead + 1, // Position is the count of people ahead plus one
+    };
+   },
+});

--- a/src/components/event-card.tsx
+++ b/src/components/event-card.tsx
@@ -1,4 +1,4 @@
-"use client"
+"use client";
 import { useUser } from "@clerk/nextjs";
 import type { Id } from "../../convex/_generated/dataModel";
 import { useQuery } from "convex/react";
@@ -6,15 +6,22 @@ import { useRouter } from "next/navigation";
 import { api } from "../../convex/_generated/api";
 
 export default function EventCard({ eventId }: { eventId: Id<"events"> }) {
-  const router = useRouter()
-  const {user} = useUser()
+  const router = useRouter();
+  const { user } = useUser();
 
-  const event = useQuery(api.events.getById,{eventId})
-  const availability = useQuery(api.events.getEventAvailability,{eventId})
+  const event = useQuery(api.events.getById, { eventId });
+  const availability = useQuery(api.events.getEventAvailability, { eventId });
 
   // does the signedin user have a ticket
-  const userTicket = useQuery()
-  return <div>
+  const userTicket = useQuery(api.tickets.getUserTicketForEvent, {
+    eventId,
+    userId: user?.id ?? "",
+  });
 
-  </div>;
+  const queuePosition = useQuery(api.waitingList.getQueuePosition, {
+    eventId,
+    userId: user?.id ?? "",
+  });
+
+  return <div></div>;
 }


### PR DESCRIPTION
- Added `getQueuePosition` query to determine a user's position in the waiting list for a specific event.
- Utilized organization-specific modules and patterns for querying the database.
- Filtered out expired entries using `WAITING_LIST_STATUS.EXPIRED`.
- Calculated the user's position by counting entries with statuses `WAITING` and `OFFERED` that were created before the user's entry.
- Ensured efficient querying by using indexed fields for filtering.
- Improved code readability with detailed comments explaining each step of the process.