### PR TITLE
chore: Configure Stripe integration with environment variables

### DIFF
--- a/src/lib/stripe.ts
+++ b/src/lib/stripe.ts
@@ -1,0 +1,9 @@
+import Stripe from "stripe";
+
+if (!process.env.STRIPE_SECRET_KEY) {
+  throw new Error(`STRIPE_SECRET_KEY is missing in .env`);
+}
+
+export const stripe = new Stripe(process.env.STRIPE_SECRET_KEY, {
+  apiVersion: "2024-12-18.acacia",
+});


### PR DESCRIPTION
- Imported Stripe library and initialized with `STRIPE_SECRET_KEY` from environment variables.
- Added error handling to ensure `STRIPE_SECRET_KEY` is present in the `.env` file.
- Set Stripe API version to `2024-12-18.acacia` for compatibility with new features.
- Ensured secure handling of API keys by using environment variables.