### PR TITLE
feat: Implement Stripe Connect customer creation with authentication …

### DIFF
--- a/convex/users.ts
+++ b/convex/users.ts
@@ -1,6 +1,8 @@
 import { v } from "convex/values";
 import { mutation, query } from "./_generated/server";
 
+
+// for stripe
 export const getUsersStripeConnectId = query({
   args: { userId: v.string() },
   handler: async (ctx, args) => {

--- a/src/actions/createStripeConnectCustomer.ts
+++ b/src/actions/createStripeConnectCustomer.ts
@@ -1,0 +1,54 @@
+"use server";
+
+import { auth } from "@clerk/nextjs/server";
+import { api } from "../../convex/_generated/api";
+import { ConvexHttpClient } from "convex/browser";
+import { stripe } from "@/lib/stripe";
+
+if (!process.env.NEXT_PUBLIC_CONVEX_URL) {
+  throw new Error(`NEXT_PUBLIC_CONVEX_URL is not set`);
+}
+
+const convex = new ConvexHttpClient(process.env.NEXT_PUBLIC_CONVEX_URL);
+
+export async function createStripeConnectCustomer() {
+  const { userId } = await auth();
+
+  if (!userId) {
+    throw new Error(`Not Authenticated`);
+  }
+
+  //   check if user already has a connected account.
+  const existingStripeConnectId = await convex.query(
+    api.users?.getUsersStripeConnectId,
+    {
+      userId,
+    },
+  );
+
+  // return
+  if (existingStripeConnectId) {
+    return { account: existingStripeConnectId };
+  }
+
+  // create new account
+  const account = await stripe.accounts.create({
+    type: "express",
+    capabilities: {
+      card_payments: { requested: true },
+      transfers: { requested: true },
+      cashapp_payments: { requested: true },
+      us_bank_account_ach_payments: { requested: true },
+      amazon_pay_payments: { requested: true },
+      samsung_pay_payments: { requested: true },
+    },
+  });
+
+  //   update user with stripe connect id
+  await convex.mutation(api.users.updateOrCreateUserStripeConnectId, {
+    userId,
+    stripeConnectId: account.id,
+  });
+
+  return { account: account.id };
+}


### PR DESCRIPTION
…and account management

- Added `createStripeConnectCustomer` function to handle the creation of Stripe Connect accounts for authenticated users.
- Utilized `auth` from `@clerk/nextjs/server` to ensure user authentication before proceeding with account creation.
- Integrated `ConvexHttpClient` to query and update user data related to Stripe Connect IDs.
- Checked for existing Stripe Connect accounts to prevent duplicate account creation.
- Configured new Stripe Connect accounts with requested capabilities for various payment methods.
- Updated user records with new Stripe Connect IDs using organization-specific API calls.