### PR TITLE
feat: Implement Stripe Checkout session creation for event ticket purchases

### DIFF
--- a/src/actions/createStripeCheckoutSession.ts
+++ b/src/actions/createStripeCheckoutSession.ts
@@ -1,0 +1,96 @@
+"use server";
+
+import { auth } from "@clerk/nextjs/server";
+import type { Id } from "../../convex/_generated/dataModel";
+import { api } from "../../convex/_generated/api";
+import { stripe } from "@/lib/stripe";
+import { DURATIONS } from "../../convex/constant";
+import { getConvexClient } from "@/lib/convex";
+import baseUrl from "@/lib/baseUrl";
+
+
+
+export type StripeCheckoutMetaData = {
+  eventId: Id<"events">;
+  userId: string;
+  waitingListId: Id<"waitingList">;
+};
+
+export async function createStripeCheckoutSession({
+  eventId,
+}: {
+  eventId: Id<"events">;
+}) {
+  const { userId } = await auth();
+  if (!userId) throw new Error("Not authenticated");
+
+  const convex = getConvexClient();
+
+  // Get event details
+  const event = await convex.query(api.events.getById, { eventId });
+  if (!event) throw new Error("Event not found");
+
+  // Get waiting list entry
+  const queuePosition = await convex.query(api.waitingList.getQueuePosition, {
+    eventId,
+    userId,
+  });
+
+  if (!queuePosition || queuePosition.status !== "offered") {
+    throw new Error("No valid ticket offer found");
+  }
+
+  const stripeConnectId = await convex.query(
+    api.users.getUsersStripeConnectId,
+    {
+      userId: event.userId,
+    },
+  );
+
+  if (!stripeConnectId) {
+    throw new Error("Stripe Connect ID not found for owner of the event!");
+  }
+
+  if (!queuePosition.offerExpiresAt) {
+    throw new Error("Ticket offer has no expiration date");
+  }
+
+  const metadata: StripeCheckoutMetaData = {
+    eventId,
+    userId,
+    waitingListId: queuePosition._id,
+  };
+
+  // Create Stripe Checkout Session
+  const session = await stripe.checkout.sessions.create(
+    {
+      payment_method_types: ["card","cashapp","amazon_pay"],
+      line_items: [
+        {
+          price_data: {
+            currency: "usd",
+            product_data: {
+              name: event.name,
+              description: event.description,
+            },
+            unit_amount: Math.round(event.price * 100),//cent
+          },
+          quantity: 1,
+        },
+      ],
+      payment_intent_data: {
+        application_fee_amount: Math.round(event.price * 100 * 0.5),//5 percent fee
+      },
+      expires_at: Math.floor(Date.now() / 1000) + DURATIONS.TICKET_OFFER / 1000, // 30 minutes (stripe checkout minimum expiration time)
+      mode: "payment",
+      success_url: `${baseUrl}/tickets/purchase-success?session_id={CHECKOUT_SESSION_ID}`,
+      cancel_url: `${baseUrl}/event/${eventId}`,
+      metadata,
+    },
+    {
+      stripeAccount: stripeConnectId,//Stripe Connect ID for event owner of the ticket (Seller)
+    },
+  );
+
+  return { sessionId: session.id, sessionUrl: session.url };
+}

--- a/src/lib/baseUrl.ts
+++ b/src/lib/baseUrl.ts
@@ -1,0 +1,6 @@
+const baseUrl =
+  process.env.NODE_ENV === "development"
+    ? "http://localhost:3000"
+    : `https://${process.env.VERCEL_PROJECT_PRODUCTION_URL}`;
+
+export default baseUrl;

--- a/src/lib/convex.ts
+++ b/src/lib/convex.ts
@@ -1,0 +1,9 @@
+import { ConvexHttpClient } from "convex/browser";
+
+// Create a client for server-side HTTP requests
+export const getConvexClient = () => {
+  if (!process.env.NEXT_PUBLIC_CONVEX_URL) {
+    throw new Error("NEXT_PUBLIC_CONVEX_URL is not set");
+  }
+  return new ConvexHttpClient(process.env.NEXT_PUBLIC_CONVEX_URL);
+};


### PR DESCRIPTION
- Added `createStripeCheckoutSession` function to handle the creation of Stripe Checkout sessions for event tickets.
- Utilized `auth` from `@clerk/nextjs/server` to ensure user authentication before proceeding with session creation.
- Integrated `getConvexClient` to query event details and waiting list positions from the Convex backend.
- Implemented error handling for authentication, event retrieval, and ticket offer validation.
- Configured Stripe Checkout session with payment methods, line items, and metadata for tracking.
- Set session expiration using `DURATIONS.TICKET_OFFER` to comply with Stripe's minimum expiration requirements.
- Constructed dynamic success and cancel URLs using `baseUrl` for seamless user experience.