### PR TITLE
# style: Update Button Color for Seller Account Creation

### DIFF
--- a/src/components/seller-dashboard.tsx
+++ b/src/components/seller-dashboard.tsx
@@ -136,7 +136,7 @@ export default function SellerDashboard() {
                     setAccountCreatePending(false);
                   }
                 }}
-                className="rounded-lg bg-blue-600 px-6 py-2 text-white transition-colors hover:bg-blue-700"
+                className="rounded-lg bg-black/80 px-6 py-2 text-white transition-colors hover:bg-black"
               >
                 Create Seller Account
               </button>


### PR DESCRIPTION
- Changed the background color of the "Create Seller Account" button to a semi-transparent black for a more modern look.
- Updated hover state to transition to solid black for visual feedback.